### PR TITLE
Improve equals constraint

### DIFF
--- a/Rules4Net.Tests/Constraints/EqualsConstraintTests.cs
+++ b/Rules4Net.Tests/Constraints/EqualsConstraintTests.cs
@@ -1,35 +1,13 @@
 ﻿using Rules4Net.Data;
 using Rules4Net.Data.Constraints;
-using Rules4Net.Engine;
-using Rules4Net.Repository;
 using Rules4Net.Tests.TestObjects.Financial;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Xunit;
 
-namespace Rules4Net.Tests.Constraints
-{    
-    public class EqualsConstraintTests : TestBase
-    {
-        [Fact]
-        public void ShouldBePossibleEvaluateRuleWithEqualsConstraint()
-        {
-            var rule = new Rule();
-            var filter = rule.AddAndFilter();
-            filter.Add(new EqualsConstraint("Name", "John Doe"));
-
-            this.AddRule(rule);
-
-            var data = new Dictionary<string, object>();
-            data["Name"] = "John Doe";
-
-            var rules = this.Engine.Evaluate(data);
-
-            Assert.Equal(1, rules.Count());
-        }
-
+namespace Rules4Net.Tests.Constraints {
+    public class EqualsConstraintTests : TestBase {
         [Fact]
         public void ShouldNotBePossibleEvaluateRuleWithEqualsConstraintAndNotEqualValue()
         {

--- a/Rules4Net.Tests/Constraints/EqualsConstraintTests.cs
+++ b/Rules4Net.Tests/Constraints/EqualsConstraintTests.cs
@@ -2,6 +2,7 @@
 using Rules4Net.Data.Constraints;
 using Rules4Net.Engine;
 using Rules4Net.Repository;
+using Rules4Net.Tests.TestObjects.Financial;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -59,6 +60,90 @@ namespace Rules4Net.Tests.Constraints
             var rules = this.Engine.Evaluate(data);
 
             Assert.Equal(0, rules.Count());
+        }
+
+        [Fact]
+        public void ShouldEvaluateBoolValue() {
+            var fakeData = new Dictionary<string, object>() { { "myProperty", true  } };
+            var sut = new EqualsConstraint("myProperty", true);
+            
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluatePrimitiveInteger() {            
+            var fakeData = new Dictionary<string, object>() { { "myProperty", 18 } };
+            var sut = new EqualsConstraint("myProperty", 18);
+            
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluateDecimalValue() {
+            var fakeData = new Dictionary<string, object>() { { "myProperty", -18.4m } };
+            var sut = new EqualsConstraint("myProperty", -18.4m);
+
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluatePrimitiveDate() {
+            var fakeData = new Dictionary<string, object>() { { "myProperty", new DateTime(2016, 12, 21) } };
+            var sut = new EqualsConstraint("myProperty", new DateTime(2016, 12, 21));
+
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluatePrimitiveChar() {
+            var fakeData = new Dictionary<string, object>() { { "myProperty", 'C' } };
+            var sut = new EqualsConstraint("myProperty", 'C');
+
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluatePrimitiveString() {
+            var fakeData = new Dictionary<string, object>() { { "myProperty", "John Doe" } };
+            var sut = new EqualsConstraint("myProperty", "John Doe");
+
+            var result = sut.Evaluate(fakeData);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ShouldEvaluateByValueComplexTypeWithEqualsOverrided() {            
+            var fakeData = new Dictionary<string, object>() { { "myProperty", new Money(12.3m, Currency.DOLAR) } };
+
+            var sut = new EqualsConstraint("myProperty", new Money(12.3m, Currency.REAL));
+            Assert.False(sut.Evaluate(fakeData));
+
+            sut = new EqualsConstraint("myProperty", new Money(12.3m, Currency.DOLAR));
+            Assert.True(sut.Evaluate(fakeData));
+        }
+
+        [Fact]
+        public void ShouldEvaluateByReferenceComplexTypeWithoutEqualsOverrided() {
+            var aComplexTypeWithNoEquals = new DummyClass(21);
+            var fakeData = new Dictionary<string, object>() { { "myProperty", aComplexTypeWithNoEquals } };
+
+            var sut = new EqualsConstraint("myProperty", new DummyClass(21));            
+            Assert.False(sut.Evaluate(fakeData));
+
+            sut = new EqualsConstraint("myProperty", aComplexTypeWithNoEquals);
+            Assert.True(sut.Evaluate(fakeData));
+        }
+    } //class
+
+    public class DummyClass {
+        public int Value { get; set; }
+        public DummyClass(int value) {
+            this.Value = value;
         }
     }
 }

--- a/Rules4Net.Tests/Rules4Net.Tests.csproj
+++ b/Rules4Net.Tests/Rules4Net.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuleEngineTests.cs" />
     <Compile Include="TestBase.cs" />
+    <Compile Include="TestObjects\Financial\Currency.cs" />
+    <Compile Include="TestObjects\Financial\Money.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rules4Net\Rules4Net.csproj">

--- a/Rules4Net.Tests/TestObjects/Financial/Currency.cs
+++ b/Rules4Net.Tests/TestObjects/Financial/Currency.cs
@@ -1,0 +1,6 @@
+﻿namespace Rules4Net.Tests.TestObjects.Financial {
+    public enum Currency {
+        DOLAR,
+        REAL
+    }
+}

--- a/Rules4Net.Tests/TestObjects/Financial/Money.cs
+++ b/Rules4Net.Tests/TestObjects/Financial/Money.cs
@@ -1,0 +1,23 @@
+﻿namespace Rules4Net.Tests.TestObjects.Financial {
+    public class Money {
+        public decimal Amount { get; }
+        public Currency Currency { get; }
+        public Money(decimal amount, Currency currency) {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public override bool Equals(object obj) {
+            var that = obj as Money;
+            if (that == null)
+                return false;
+
+            return that.Amount == this.Amount 
+                        && that.Currency == this.Currency;
+        }
+
+        public override int GetHashCode() {
+            return Amount.GetHashCode() ^ Currency.GetHashCode();
+        }
+    } //class
+}

--- a/Rules4Net/Data/Constraints/EqualsConstraint.cs
+++ b/Rules4Net/Data/Constraints/EqualsConstraint.cs
@@ -1,27 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
-namespace Rules4Net.Data.Constraints
-{
-    public class EqualsConstraint : IConstraint
-    {
+namespace Rules4Net.Data.Constraints {
+    public class EqualsConstraint : IConstraint {
         private string _property;
         private object _value;
 
-        public EqualsConstraint(string property, object value)
-        {
+        public EqualsConstraint(string property, object value) {
             this._property = property;
             this._value = value;
         }
 
-        public virtual bool Evaluate(IDictionary<string, object> data)
-        {
+        public virtual bool Evaluate(IDictionary<string, object> data) {
             if (!data.ContainsKey(_property))
                 return false;
 
-            return data[_property] == this._value;
-        }
-    }
+            var value = data[_property];
+            return value != null && value.Equals(this._value); 
+        }        
+    } //class
 }


### PR DESCRIPTION
Changed the comparison in EqualsConstraint from **==** to use **Equals()** method. 
"==" operator compares by reference (except string), so we cannot for instance compare two objects from a type that override the equals method.

[http://stackoverflow.com/questions/814878/c-sharp-difference-between-and-equals](http://stackoverflow.com/questions/814878/c-sharp-difference-between-and-equals)

It solves the problem in issue #4