### PR TITLE
Turn filter into a constraint

### DIFF
--- a/Rules4Net.Tests/Filters/AndFilterTest.cs
+++ b/Rules4Net.Tests/Filters/AndFilterTest.cs
@@ -1,0 +1,41 @@
+﻿using Rules4Net.Data;
+using Rules4Net.Data.Constraints;
+using Rules4Net.Data.Filters;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Rules4Net.Tests.Filters {
+    public class AndFilterTest {
+        [Fact]
+        public void ShouldBeAConstraint() {
+            AndFilter sut = new AndFilter();
+            Assert.IsAssignableFrom<IConstraint>(sut);
+        }
+
+
+        [Fact]
+        public void ShouldBeComposableWithOthersFilters() {
+            var aTrueFilter = new FakeTrueFilter();
+            var sut = new AndFilter(new Filter[] { new AndFilter(new Filter[] { aTrueFilter }), new FakeTrueFilter() });
+            Assert.True(sut.Evaluate(null));
+            Assert.True(aTrueFilter.Called);
+        }
+
+    } //class
+
+    public class FakeTrueFilter : Filter {
+        public bool Called { get; set; } = false;
+        public override bool Evaluate(IDictionary<string, object> data) {
+            Called = true;
+            return true;
+        }
+    }
+
+    public class FakeFalseFilter : Filter {
+        public bool Called { get; set; } = false;
+        public override bool Evaluate(IDictionary<string, object> data) {
+            Called = true;
+            return false;
+        }
+    }
+}

--- a/Rules4Net.Tests/Filters/OrFilterTest.cs
+++ b/Rules4Net.Tests/Filters/OrFilterTest.cs
@@ -1,0 +1,26 @@
+﻿using Rules4Net.Data;
+using Rules4Net.Data.Constraints;
+using Rules4Net.Data.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Rules4Net.Tests.Filters {
+    public class OrFilterTest {
+        [Fact]
+        public void ShouldBeAConstraint() {
+            var sut = new OrFilter(new Rule());
+            Assert.IsAssignableFrom<IConstraint>(sut);
+        }
+        
+        [Fact]
+        public void ShouldBeComposableWithOthersFilters() {
+            var aFalseFilter = new FakeFalseFilter();
+            var sut = new OrFilter(new Filter[] { new OrFilter(new Filter[] { aFalseFilter }), new FakeTrueFilter() });
+            Assert.True(sut.Evaluate(null));
+            Assert.True(aFalseFilter.Called);
+        }
+    }    
+}

--- a/Rules4Net.Tests/Rules4Net.Tests.csproj
+++ b/Rules4Net.Tests/Rules4Net.Tests.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Constraints\EqualsConstraintTests.cs" />
     <Compile Include="Constraints\EndsWithConstraintTests.cs" />
     <Compile Include="Constraints\StartsWithConstraintTests.cs" />
+    <Compile Include="Filters\AndFilterTest.cs" />
+    <Compile Include="Filters\OrFilterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuleEngineTests.cs" />
     <Compile Include="TestBase.cs" />

--- a/Rules4Net/Data/Filters/Filter.cs
+++ b/Rules4Net/Data/Filters/Filter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Rules4Net.Data
 {
-    public abstract class Filter
+    public abstract class Filter : IConstraint
     {
         protected Filter() {            
             this.Constraints = new List<IConstraint>();


### PR DESCRIPTION
Treating a filter as constraint open the possibility to compose Filters to create a complex set of conditions.
The complex conditions of a rule acts like a tree, and can be resolved in diferent ways.

This is referenced in the issue   #9 
